### PR TITLE
chore: preparation for Open Source release of docs repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Create a report to help us improve
+title: "bug:"
+labels: ["bug"]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      1. With this config...
+      1. Run '...'
+      1. See error...
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Screenshots
+    description: If applicable, add screenshots to help explain your problem.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an idea for this project
+title: "feat:"
+labels: ["enhancement"]
+body:
+- type: textarea
+  attributes:
+    label: Is your feature request related to a problem? Please describe.
+    description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Describe the solution you'd like
+    description: A clear and concise description of what you want to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Describe alternatives you've considered
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: Add any other context or screenshots about the feature request here.
+    render: markdown
+  validations:
+    required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Description
+
+Please describe the purpose of this pull request. What does it change or add?
+
+## Checklist
+
+- [ ] My changes follow the project’s contributing guidelines
+- [ ] I have proofread the changes and fixed any typos
+- [ ] I have verified formatting and links in the docs
+- [ ] I have checked that the sidebar or TOC is updated if needed
+- [ ] I have previewed the changes locally
+
+## Related Issues or PRs
+
+Link to any related issues, discussions, or previous PRs.
+
+## Notes for Reviewers
+
+Add any specific areas you'd like feedback on or questions for reviewers.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contribute to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best, not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[info@veridian.id](mailto:info%40veridian.id).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,32 @@
+# Contributing to this project
+
+First off, thanks for taking the time to contribute! 🎉
+
+When contributing to this repository, please first describe the change you wish to make [via an issue](https://github.com/cardano-foundation/veridian-docs/issues/new) before making a change.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+
+## Issues and pull requests
+
+### Bug reports
+
+[Submit a bug report](https://github.com/cardano-foundation/veridian-docs/issues/new?assignees=&labels=&projects=&template=bug_report.yml&title=%5BBUG%5D+) using the provided template for bug reports. If the template does not fit your purpose start with a blank issue.
+
+For bug reports, it's very important to fill in the information in the structure provided by the templates to help us analyzing the bug.
+
+### Feature requests and ideas
+
+[Submit a feature request](https://github.com/cardano-foundation/veridian-docs/issues/new?assignees=&labels=&projects=&template=feature_request.yml&title=%5BFEATURE%5D+) using the provided template for feature requests. If the template does not fit your purpose start with a blank issue but make sure the name starts with a "FEATURE" in square brackets.
+
+### Creating a pull request
+
+Thank you for contributing your changes by opening a pull requests! To get something merged we usually require:
+
+- The pull request should successfully clear existing tests.
+- ❗ Description of the changes - please follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification) as we use it to automatically generate our CHANGELOG ❗This repository has a githook to ensure the use of conventional commits. To configure it run this command on the root of the project before creating your first commit:
+
+```
+make init
+```
+
+- Change is related to an issue (feature request or bug report) - ideally discussed beforehand
+- Well-scoped - we prefer multiple PRs, rather than a big one

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
-# Veridian Docs 
+<div align="center">
+   <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="utils/icons/VeridianDocsLogoDark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="utils/icons/VeridianDocsLogoLight.svg">
+      <img alt="Veridian Docs" src="utils/icons/VeridianDocsLogoDark.svg">
+   </picture>
 
-[![CC BY 4.0][cc-by-shield]][cc-by]
+   <hr />
+   <h1 align="center" style="border-bottom: none">Veridian Docs</h1>
 
+   [![CC BY 4.0][cc-by-shield]][cc-by]
+   ![Discord](https://img.shields.io/discord/1022471509173882950)
+</div>
 
-Welcome to the documentation site repository for the Veridian platform.
+Welcome to the documentation site repository for the [Veridian platform](https://www.veridian.id/).
 This site is generated using [Nextra](https://nextra.site/), a Next.js based static site generator.
 Follow the instructions below to get started with the project.
 
@@ -41,6 +50,17 @@ npm run dev
 This will start the server and you can view the site by navigating to http://localhost:3000 in your web browser.
 The server supports hot reloading, so any changes you make to the files will automatically be reflected in the browser.
 
+# Contributing
+
+All contributions are welcome!
+Please feel free to open a new thread on the issue tracker or submit a new pull request.
+
+Please read [Contributing](CONTRIBUTING.md) in advance.
+Thank you for contributing!
+
+## Additional Documents
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security](SECURITY.md)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Veridian Wallet | Cardano Foundation project takes security seriously. We appreciate your efforts in disclosing any potential vulnerabilities responsibly.
+
+If you have discovered a security vulnerability within this project, please report it to us as soon as possible. We encourage responsible disclosure and kindly ask you to follow the guidelines outlined below.
+
+## Guidelines for Responsible Disclosure
+
+To ensure that the security vulnerability is properly addressed, we request that you adhere to the following guidelines:
+
+1. **Do not exploit the vulnerability**: Do not attempt to exploit the vulnerability or gain unauthorized access to any user data. Only perform actions that are necessary to identify or validate the vulnerability.
+
+2. **Privately disclose the vulnerability**: Please do not disclose the vulnerability publicly before we have had an opportunity to investigate and address the issue. We appreciate your discretion.
+
+3. **Contact us directly**: Send an email to our team at [info@veridian.id](mailto:info%40veridian.id?subject=Veridian%20Security%20Vulnerability%20Report) with the subject line: "Veridian Security Vulnerability Report", or contact our team at [Discord](https://discord.gg/4WVNHgQ7bP).
+
+4. **Provide detailed information**: In your report, please include detailed information about the vulnerability, including steps to reproduce it and any potential impact.
+
+5. **Share your contact information**: We would appreciate it if you could provide your name and contact information, including your email address or other means of communication, so we can reach out to you if we require any additional information.
+
+6. **Keep communication confidential**: While we investigate and address the vulnerability, we kindly request that you keep all communication related to the vulnerability confidential.
+
+7. **Allow time for a response**: We strive to acknowledge vulnerability reports as soon as possible and will make every effort to respond within a reasonable timeframe. Please be patient while we investigate and address the reported issue.
+
+## Recognition and Acknowledgment
+
+We believe in recognizing the valuable contributions of the security community and are open to acknowledging those who responsibly disclose vulnerabilities. If you would like to be acknowledged for your responsible disclosure, please let us know when reporting the vulnerability. However, we respect your privacy and will not disclose any personal information without your explicit consent.
+
+Thank you for helping us ensure the security of the Veridian Wallet | Cardano Foundation project and the broader Cardano ecosystem. Your efforts are greatly appreciated.

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -33,10 +33,8 @@ export default async function RootLayout({ children }) {
         <Layout
           navbar={<NavbarWithThemeLogo />}
           pageMap={await getPageMap()}
-          docsRepositoryBase={DOCUMENTATION_GITHUB_REPO_URL}
+          docsRepositoryBase={DOCUMENTATION_GITHUB_REPO_URL + "/tree/main"}
           footer={footer}
-          editLink={null}
-          feedback={{ content: null }}
         >
           {children}
         </Layout>


### PR DESCRIPTION
**Jira Ticket:** [DTIS-2279](https://cardanofoundation.atlassian.net/browse/DTIS-2279)

This PR prepares the repository for the open source release of himself. This PR includes:
- CODE_OF_CONDUCT, CONTRIBUTING and SECURITY files copied and slightly modified from the [Veridian Wallet repository](https://github.com/cardano-foundation/veridian-wallet)
- Created templates for:
    - Pull Requests
    - Bug Reports
    - Future Requests
 - Updated the README file:
    - Added new Veridian Docs Logo and title on top of the document
    - Added Contributing section
 - In the nextra project configuration the links to edit the current file and create an issue from the website has been enabled again. 
<img width="1269" alt="Screenshot 2025-06-03 at 11 02 13" src="https://github.com/user-attachments/assets/70f355ea-914f-49a5-8b1f-0e7542c557ca" />


[DTIS-2279]: https://cardanofoundation.atlassian.net/browse/DTIS-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ