### PR TITLE
Update KERIA_IURLS export command with env file

### DIFF
--- a/content/selfdeployment.mdx
+++ b/content/selfdeployment.mdx
@@ -69,7 +69,7 @@ docker compose \
 
     b. Gather witnesses' OOBIs and check that they all (0-5) look correct:
     ```bash
-    export KERIA_IURLS=$(INITIAL_PORT=5642; for wit in $(seq 0 5); do OOBI=$(docker compose -f docker-compose.production.traefik.yaml logs witness-$wit 2>/dev/null | grep Witness.wit | awk '{print $NF}'); echo http://witness-$wit:$(( INITIAL_PORT + wit ))/oobi/${OOBI}/controller?role=witness; done | xargs echo)
+    export KERIA_IURLS=$(INITIAL_PORT=5642; for wit in $(seq 0 5); do OOBI=$(docker compose -f docker-compose.production.traefik.yaml --env-file .env.production logs witness-$wit 2>/dev/null | grep Witness.wit | awk '{print $NF}'); echo "http://witness-$wit:$(( INITIAL_PORT + wit ))/oobi/${OOBI}/controller?role=witness"; done | xargs echo)
     ```
     ```bash
     echo $KERIA_IURLS


### PR DESCRIPTION
- The environment file for Docker Compose is required to retrieve the OBI;
- To be compatible with zsh, the generated URL must be quoted.

## Description

Please describe the purpose of this pull request. What does it change or add?
This PR fixes the script for exporting KERIA_IURLS to address two issues:
- Added `--env-file` parameter: The Docker Compose command now includes `--env-file .env.production` to ensure environment variables are properly loaded when retrieving OOBI data from witness containers.
- Fixed zsh compatibility: The generated URLs are now quoted to prevent zsh from interpreting the characters as a glob pattern, which was causing a "no matches found" error. The script now works correctly in both bash and zsh environments.

## Checklist

- [x] My changes follow the project’s contributing guidelines
- [x] I have proofread the changes and fixed any typos
- [x] I have verified formatting and links in the docs
- [x] I have checked that the sidebar or TOC is updated if needed
- [x] I have previewed the changes locally

## Related Issues or PRs

Link to any related issues, discussions, or previous PRs.
-

## Notes for Reviewers

Add any specific areas you'd like feedback on or questions for reviewers.
-